### PR TITLE
Cleaning up PositionPreset objects with deleted FacilityLocation and Camera Device

### DIFF
--- a/camera_device/tasks/__init__.py
+++ b/camera_device/tasks/__init__.py
@@ -1,0 +1,15 @@
+from celery import Celery, current_app
+from celery.schedules import crontab
+
+from camera_device.tasks.cleanup_possition_presets import (
+    cleanup_possition_presets,
+)
+
+
+@current_app.on_after_finalize.connect
+def setup_periodic_tasks(sender: Celery, **kwargs):
+    sender.add_periodic_task(
+        crontab(hour="0", minute="0"),
+        cleanup_possition_presets.s(),
+        name="cleanup_possition_presets",
+    )

--- a/camera_device/tasks/cleanup_possition_presets.py
+++ b/camera_device/tasks/cleanup_possition_presets.py
@@ -2,6 +2,7 @@ from logging import Logger
 
 from celery import shared_task
 from celery.utils.log import get_task_logger
+from django.db.models import Q
 
 from camera_device.models import PositionPreset
 
@@ -14,5 +15,7 @@ def cleanup_possition_presets():
     Deletes PositionPreset objects whose associated FacilityLocation has been deleted.
     """
     logger.info("Cleaning up PositionPreset objects with deleted FacilityLocation")
-    queryset = PositionPreset.objects.filter(location__deleted=True)
-    queryset.delete()
+    queryset = PositionPreset.objects.filter(
+        Q(location__deleted=True) | Q(camera__deleted=True)
+    )
+    queryset.update(deleted=True)

--- a/camera_device/tasks/cleanup_possition_presets.py
+++ b/camera_device/tasks/cleanup_possition_presets.py
@@ -1,0 +1,18 @@
+from logging import Logger
+
+from celery import shared_task
+from celery.utils.log import get_task_logger
+
+from camera_device.models import PositionPreset
+
+logger: Logger = get_task_logger(__name__)
+
+
+@shared_task
+def cleanup_possition_presets():
+    """
+    Deletes PositionPreset objects whose associated FacilityLocation has been deleted.
+    """
+    logger.info("Cleaning up PositionPreset objects with deleted FacilityLocation")
+    queryset = PositionPreset.objects.filter(location__deleted=True)
+    queryset.delete()

--- a/camera_device/tasks/cleanup_possition_presets.py
+++ b/camera_device/tasks/cleanup_possition_presets.py
@@ -12,7 +12,7 @@ logger: Logger = get_task_logger(__name__)
 @shared_task
 def cleanup_possition_presets():
     """
-    Deletes PositionPreset objects whose associated FacilityLocation has been deleted.
+    Deletes PositionPreset objects whose associated FacilityLocation or Camera device have been deleted.
     """
     logger.info("Cleaning up PositionPreset objects with deleted FacilityLocation")
     queryset = PositionPreset.objects.filter(

--- a/camera_device/tasks/cleanup_possition_presets.py
+++ b/camera_device/tasks/cleanup_possition_presets.py
@@ -14,7 +14,7 @@ def cleanup_possition_presets():
     """
     Deletes PositionPreset objects whose associated FacilityLocation or Camera device have been deleted.
     """
-    logger.info("Cleaning up PositionPreset objects with deleted FacilityLocation")
+    logger.info("Cleaning up orphaned PositionPreset objects")
     queryset = PositionPreset.objects.filter(
         Q(location__deleted=True) | Q(camera__deleted=True)
     )


### PR DESCRIPTION
Fix : #12 
Added a scheduled cron job that runs daily mid-night to detect and clean up such unused position presets automatically.