### PR TITLE
Fixes issue with de-serialization when linked gateway is deleted

### DIFF
--- a/camera_device/device.py
+++ b/camera_device/device.py
@@ -34,8 +34,7 @@ class CameraDevice(DeviceTypeBase):
     def retrieve(self, obj):
         metadata = obj.metadata
         gateway = self.get_gateway_device(obj)
-        if gateway:
-            metadata["gateway"] = GatewayDeviceReadSpec.serialize(gateway)
+        metadata["gateway"] = GatewayDeviceReadSpec.serialize(gateway) if gateway else None
         return CameraDeviceMetadataReadSpec(**metadata).model_dump(mode="json")
 
     def perform_action(self, obj, action, request):

--- a/vitals_observation_device/device.py
+++ b/vitals_observation_device/device.py
@@ -35,8 +35,7 @@ class VitalsObservationDevice(DeviceTypeBase):
     def retrieve(self, obj):
         metadata = obj.metadata
         gateway = self.get_gateway_device(obj)
-        if gateway:
-            metadata["gateway"] = GatewayDeviceReadSpec.serialize(gateway)
+        metadata["gateway"] = GatewayDeviceReadSpec.serialize(gateway) if gateway else None
         return VitalsObservationDeviceMetadataReadSpec(**metadata).model_dump(
             mode="json"
         )


### PR DESCRIPTION
Set the gateway field in the device metadata to None for gateways that have been deleted.